### PR TITLE
Allow timers to be unreferenced

### DIFF
--- a/src/Policy.ts
+++ b/src/Policy.ts
@@ -2,8 +2,13 @@ import { IBreaker } from './breaker/Breaker';
 import { BulkheadPolicy } from './BulkheadPolicy';
 import { CircuitBreakerPolicy } from './CircuitBreakerPolicy';
 import { FallbackPolicy } from './FallbackPolicy';
-import { IRetryContext, RetryPolicy } from './RetryPolicy';
-import { ICancellationContext, TimeoutPolicy, TimeoutStrategy } from './TimeoutPolicy';
+import { IRetryContext, IRetryOptions, RetryPolicy } from './RetryPolicy';
+import {
+  ICancellationContext,
+  ITimeoutOptions,
+  TimeoutPolicy,
+  TimeoutStrategy,
+} from './TimeoutPolicy';
 
 type Constructor<T> = new (...args: any) => T;
 
@@ -191,8 +196,8 @@ export class Policy {
    * {@link TaskCancelledError} when the timeout is reached, in addition to
    * marking the passed token as failed.
    */
-  public static timeout(duration: number, strategy: TimeoutStrategy) {
-    return new TimeoutPolicy(duration, strategy);
+  public static timeout(duration: number, strategy: TimeoutStrategy, options?: ITimeoutOptions) {
+    return new TimeoutPolicy(duration, strategy, options);
   }
 
   /**
@@ -335,8 +340,9 @@ export class Policy {
   /**
    * Returns a retry policy builder.
    */
-  public retry() {
+  public retry(options?: IRetryOptions) {
     return new RetryPolicy({
+      ...options,
       errorFilter: this.options.errorFilter,
       resultFilter: this.options.resultFilter,
     });


### PR DESCRIPTION
By default, unreference timers created by the TimeoutPolicy. Add an option to keep the timer referenced.

Add an option when buliding a RetryPolicy to unreference the timer.

Fixes #11.

---

Specifying an `unref` option when creating the policy seems the most natural to me. It's a bit awkward in `Policy.timeout()` though since that function already takes two positional arguments. Rather than adding a third I've added an optional `options` object instead. But maybe `Policy.timeout()` should be changed to take a single options object.

It's hard to test `unref()`. I could stub `setTimeout`, or perhaps we can do manual testing. What do you think @connor4312?