### PR TITLE
Make backoff.duration  available until the first next call.

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "typescript",
+			"tsconfig": "tsconfig.json",
+			"option": "watch",
+			"problemMatcher": [
+				"$tsc-watch"
+			],
+			"group": "build",
+			"label": "tsc: watch - tsconfig.json"
+		}
+	]
+}

--- a/src/RetryPolicy.test.ts
+++ b/src/RetryPolicy.test.ts
@@ -177,11 +177,11 @@ describe('RetryPolicy', () => {
       Policy.handleAll()
         .retry()
         .attempts(3)
-        .execute(({ cancellationToken: cancellation }) => {
+        .execute(({ cancellationToken }) => {
           calls++;
-          expect(cancellation.isCancellationRequested).to.be.false;
+          expect(cancellationToken.isCancellationRequested).to.be.false;
           parent.cancel();
-          expect(cancellation.isCancellationRequested).to.be.true;
+          expect(cancellationToken.isCancellationRequested).to.be.true;
           throw err;
         }, parent.token),
     ).to.eventually.be.rejectedWith(err);

--- a/src/RetryPolicy.ts
+++ b/src/RetryPolicy.ts
@@ -1,4 +1,9 @@
-import { ExponentialBackoff, IBackoff, IExponentialBackoffOptions } from './backoff/Backoff';
+import {
+  ExponentialBackoff,
+  IBackoff,
+  IBackoffFactory,
+  IExponentialBackoffOptions,
+} from './backoff/Backoff';
 import { CompositeBackoff, CompositeBias } from './backoff/CompositeBackoff';
 import { ConstantBackoff } from './backoff/ConstantBackoff';
 import { DelegateBackoff, DelegateBackoffFn } from './backoff/DelegateBackoff';
@@ -38,7 +43,7 @@ export interface IRetryBackoffContext<R> extends IRetryContext {
 }
 
 export interface IRetryPolicyConfig {
-  backoff?: IBackoff<IRetryBackoffContext<unknown>>;
+  backoff?: IBackoffFactory<IRetryBackoffContext<unknown>>;
 
   /**
    * Whether to unreference the internal timer. This means the policy will not
@@ -140,22 +145,32 @@ export class RetryPolicy implements IPolicy<IRetryContext> {
     fn: (context: IRetryContext) => PromiseLike<T> | T,
     cancellationToken = CancellationToken.None,
   ): Promise<T> {
-    let backoff: IBackoff<IRetryBackoffContext<unknown>> | undefined =
+    let factory: IBackoffFactory<IRetryBackoffContext<unknown>> =
       this.options.backoff || new ConstantBackoff(0, 1);
+    let backoff: IBackoff<IRetryBackoffContext<unknown>> | undefined;
     for (let retries = 0; ; retries++) {
       const result = await this.executor.invoke(fn, { attempt: retries, cancellationToken });
       if ('success' in result) {
         return result.success;
       }
-      backoff = backoff?.next({ attempt: retries + 1, cancellationToken, result });
-      if (backoff && !cancellationToken.isCancellationRequested) {
-        const delayDuration = backoff.duration();
-        const delayPromise = delay(delayDuration, !!this.options.unref);
-        // A little sneaky reordering here lets us use Sinon's fake timers
-        // when we get an emission in our tests.
-        this.onRetryEmitter.emit({ ...result, delay: delayDuration });
-        await delayPromise;
-        continue;
+
+      if (!cancellationToken.isCancellationRequested) {
+        const context = { attempt: retries + 1, cancellationToken, result };
+        if (retries === 0) {
+          backoff = factory.next(context);
+        } else if (backoff) {
+          backoff = backoff.next(context);
+        }
+
+        if (backoff) {
+          const delayDuration = backoff.duration;
+          const delayPromise = delay(delayDuration, !!this.options.unref);
+          // A little sneaky reordering here lets us use Sinon's fake timers
+          // when we get an emission in our tests.
+          this.onRetryEmitter.emit({ ...result, delay: delayDuration });
+          await delayPromise;
+          continue;
+        }
       }
 
       this.onGiveUpEmitter.emit(result);
@@ -167,7 +182,10 @@ export class RetryPolicy implements IPolicy<IRetryContext> {
     }
   }
 
-  private composeBackoff(bias: CompositeBias, backoff: IBackoff<IRetryBackoffContext<unknown>>) {
+  private composeBackoff(
+    bias: CompositeBias,
+    backoff: IBackoffFactory<IRetryBackoffContext<unknown>>,
+  ) {
     if (this.options.backoff) {
       backoff = new CompositeBackoff(bias, this.options.backoff, backoff);
     }

--- a/src/RetryPolicy.ts
+++ b/src/RetryPolicy.ts
@@ -145,7 +145,7 @@ export class RetryPolicy implements IPolicy<IRetryContext> {
     fn: (context: IRetryContext) => PromiseLike<T> | T,
     cancellationToken = CancellationToken.None,
   ): Promise<T> {
-    let factory: IBackoffFactory<IRetryBackoffContext<unknown>> =
+    const factory: IBackoffFactory<IRetryBackoffContext<unknown>> =
       this.options.backoff || new ConstantBackoff(0, 1);
     let backoff: IBackoff<IRetryBackoffContext<unknown>> | undefined;
     for (let retries = 0; ; retries++) {

--- a/src/RetryPolicy.ts
+++ b/src/RetryPolicy.ts
@@ -147,7 +147,7 @@ export class RetryPolicy implements IPolicy<IRetryContext> {
       if ('success' in result) {
         return result.success;
       }
-
+      backoff = backoff?.next({ attempt: retries + 1, cancellationToken, result });
       if (backoff && !cancellationToken.isCancellationRequested) {
         const delayDuration = backoff.duration();
         const delayPromise = delay(delayDuration, !!this.options.unref);
@@ -155,7 +155,6 @@ export class RetryPolicy implements IPolicy<IRetryContext> {
         // when we get an emission in our tests.
         this.onRetryEmitter.emit({ ...result, delay: delayDuration });
         await delayPromise;
-        backoff = backoff.next({ attempt: retries + 1, cancellationToken, result });
         continue;
       }
 

--- a/src/backoff/Backoff.test.ts
+++ b/src/backoff/Backoff.test.ts
@@ -14,8 +14,8 @@ export const expectDurations = <T>(
       continue;
     }
 
-    actual.push(backoff.duration());
     backoff = backoff.next(context as T);
+    actual.push(backoff?.duration());
   }
 
   expect(actual).to.deep.equal(expected);

--- a/src/backoff/Backoff.test.ts
+++ b/src/backoff/Backoff.test.ts
@@ -1,12 +1,13 @@
 import { expect } from 'chai';
-import { IBackoff } from './Backoff';
+import { IBackoffFactory } from './Backoff';
 
 export const expectDurations = <T>(
-  backoff: IBackoff<T> | undefined,
+  backoffFactory: IBackoffFactory<T> | undefined,
   expected: ReadonlyArray<number | undefined>,
   context?: T,
 ) => {
   const actual: Array<number | undefined> = [];
+  let backoff = backoffFactory?.next(context as T);
   // tslint:disable-next-line: prefer-for-of
   for (let i = 0; i < expected.length; i++) {
     if (!backoff) {
@@ -14,8 +15,8 @@ export const expectDurations = <T>(
       continue;
     }
 
+    actual.push(backoff?.duration);
     backoff = backoff.next(context as T);
-    actual.push(backoff?.duration());
   }
 
   expect(actual).to.deep.equal(expected);

--- a/src/backoff/Backoff.ts
+++ b/src/backoff/Backoff.ts
@@ -1,17 +1,22 @@
 /**
  * A generic type that returns backoff intervals.
  */
-export interface IBackoff<T> {
+export interface IBackoffFactory<T> {
+  /**
+   * Returns the first backoff duration. Can return "undefined" to signal
+   * that we should not back off.
+   */
+  next(context: T): IBackoff<T> | undefined;
+}
+
+/**
+ * A generic type that returns backoff intervals.
+ */
+export interface IBackoff<T> extends IBackoffFactory<T> {
   /**
    * Returns the number of milliseconds to wait for this backoff attempt.
    */
-  duration(): number;
-
-  /**
-   * Returns the next backoff duration. Can return "undefined" to signal
-   * that we should stop backing off.
-   */
-  next(context: T): IBackoff<T> | undefined;
+  readonly duration: number;
 }
 
 export * from './CompositeBackoff';

--- a/src/backoff/CompositeBackoff.test.ts
+++ b/src/backoff/CompositeBackoff.test.ts
@@ -8,10 +8,10 @@ describe('CompositeBackoff', () => {
     new CompositeBackoff(bias, new ConstantBackoff(10, 4), new ConstantBackoff(20, 2));
 
   it('biases correctly', () => {
-    expect(withBias('a').next({})?.duration()).to.equal(10);
-    expect(withBias('b').next({})?.duration()).to.equal(20);
-    expect(withBias('min').next({})?.duration()).to.equal(10);
-    expect(withBias('max').next({})?.duration()).to.equal(20);
+    expect(withBias('a').next(undefined)?.duration).to.equal(10);
+    expect(withBias('b').next(undefined)?.duration).to.equal(20);
+    expect(withBias('min').next(undefined)?.duration).to.equal(10);
+    expect(withBias('max').next(undefined)?.duration).to.equal(20);
   });
 
   it('limits the number of retries', () => {

--- a/src/backoff/CompositeBackoff.test.ts
+++ b/src/backoff/CompositeBackoff.test.ts
@@ -8,10 +8,10 @@ describe('CompositeBackoff', () => {
     new CompositeBackoff(bias, new ConstantBackoff(10, 4), new ConstantBackoff(20, 2));
 
   it('biases correctly', () => {
-    expect(withBias('a').duration()).to.equal(10);
-    expect(withBias('b').duration()).to.equal(20);
-    expect(withBias('min').duration()).to.equal(10);
-    expect(withBias('max').duration()).to.equal(20);
+    expect(withBias('a').next({})?.duration()).to.equal(10);
+    expect(withBias('b').next({})?.duration()).to.equal(20);
+    expect(withBias('min').next({})?.duration()).to.equal(10);
+    expect(withBias('max').next({})?.duration()).to.equal(20);
   });
 
   it('limits the number of retries', () => {

--- a/src/backoff/ConstantBackoff.ts
+++ b/src/backoff/ConstantBackoff.ts
@@ -13,7 +13,7 @@ export class ConstantBackoff implements IBackoff<void> {
    */
   public duration() {
     if (this.index === -1) {
-      throw new Error(`duration is avaiable until the first next call`);
+      throw new Error('duration is avaiable until the first next call');
     }
     return this.interval;
   }

--- a/src/backoff/ConstantBackoff.ts
+++ b/src/backoff/ConstantBackoff.ts
@@ -1,34 +1,16 @@
-import { IBackoff } from './Backoff';
+import { IBackoff, IBackoffFactory } from './Backoff';
 
 /**
  * Backoff that returns a constant interval.
  */
-export class ConstantBackoff implements IBackoff<void> {
-  private index = -1;
-
+export class ConstantBackoff implements IBackoffFactory<unknown> {
   constructor(private readonly interval: number, private readonly limit?: number) {}
 
   /**
    * @inheritdoc
    */
-  public duration() {
-    if (this.index === -1) {
-      throw new Error('duration is avaiable until the first next call');
-    }
-    return this.interval;
-  }
-
-  /**
-   * @inheritdoc
-   */
   public next() {
-    if (this.limit && this.index >= this.limit - 1) {
-      return undefined;
-    }
-
-    const b = new ConstantBackoff(this.interval, this.limit);
-    b.index = this.index + 1;
-    return b;
+    return instance(this.interval, this.limit);
   }
 }
 
@@ -36,3 +18,18 @@ export class ConstantBackoff implements IBackoff<void> {
  * Backoff that never retries.
  */
 export const NeverRetryBackoff = new ConstantBackoff(0, 0);
+
+const instance = (interval: number, limit: number | undefined, index = 0): IBackoff<unknown> => ({
+  duration: interval,
+  next() {
+    if (limit === undefined) {
+      return this;
+    }
+
+    if (index >= limit - 1) {
+      return undefined;
+    }
+
+    return instance(interval, limit, index + 1);
+  },
+});

--- a/src/backoff/ConstantBackoff.ts
+++ b/src/backoff/ConstantBackoff.ts
@@ -4,7 +4,7 @@ import { IBackoff } from './Backoff';
  * Backoff that returns a constant interval.
  */
 export class ConstantBackoff implements IBackoff<void> {
-  private index = 0;
+  private index = -1;
 
   constructor(private readonly interval: number, private readonly limit?: number) {}
 
@@ -12,6 +12,9 @@ export class ConstantBackoff implements IBackoff<void> {
    * @inheritdoc
    */
   public duration() {
+    if (this.index === -1) {
+      throw new Error(`duration is avaiable until the first next call`);
+    }
     return this.interval;
   }
 
@@ -19,11 +22,7 @@ export class ConstantBackoff implements IBackoff<void> {
    * @inheritdoc
    */
   public next() {
-    if (this.limit === undefined) {
-      return this;
-    }
-
-    if (this.index >= this.limit - 1) {
+    if (this.limit && this.index >= this.limit - 1) {
       return undefined;
     }
 

--- a/src/backoff/DelegateBackoff.test.ts
+++ b/src/backoff/DelegateBackoff.test.ts
@@ -5,7 +5,7 @@ import { DelegateBackoff } from './DelegateBackoff';
 describe('DelegateBackoff', () => {
   it('passes through the context and sets next delay', () => {
     const b = new DelegateBackoff<number>(v => v * 2);
-    expect(b.next(4)!.duration()).to.equal(8);
+    expect(b.next(4)!.duration).to.equal(8);
   });
 
   it('halts delegate function returns undefined', () => {

--- a/src/backoff/DelegateBackoff.test.ts
+++ b/src/backoff/DelegateBackoff.test.ts
@@ -19,6 +19,6 @@ describe('DelegateBackoff', () => {
       return { delay: n, state: n };
     });
 
-    expectDurations(b, [0, 9, 81, 6561]);
+    expectDurations(b, [9, 81, 6561, 43046721]);
   });
 });

--- a/src/backoff/DelegateBackoff.ts
+++ b/src/backoff/DelegateBackoff.ts
@@ -21,7 +21,7 @@ export class DelegateBackoff<T, S = void> implements IBackoff<T> {
    */
   public duration() {
     if (this.attempts === -1) {
-      throw new Error(`duration is avaiable until the first next call`);
+      throw new Error('duration is avaiable until the first next call');
     }
     return this.current;
   }

--- a/src/backoff/DelegateBackoff.ts
+++ b/src/backoff/DelegateBackoff.ts
@@ -12,6 +12,7 @@ export type DelegateBackoffFn<T, S = void> = (
  */
 export class DelegateBackoff<T, S = void> implements IBackoff<T> {
   private current: number = 0;
+  private attempts: number = -1;
 
   constructor(private readonly fn: DelegateBackoffFn<T, S>, private readonly state?: S) {}
 
@@ -19,6 +20,9 @@ export class DelegateBackoff<T, S = void> implements IBackoff<T> {
    * @inheritdoc
    */
   public duration() {
+    if (this.attempts === -1) {
+      throw new Error(`duration is avaiable until the first next call`);
+    }
     return this.current;
   }
 
@@ -39,6 +43,7 @@ export class DelegateBackoff<T, S = void> implements IBackoff<T> {
       b = new DelegateBackoff(this.fn, result.state);
       b.current = result.delay;
     }
+    b.attempts = this.attempts + 1;
 
     return b;
   }

--- a/src/backoff/DelegateBackoff.ts
+++ b/src/backoff/DelegateBackoff.ts
@@ -1,4 +1,4 @@
-import { IBackoff } from './Backoff';
+import { IBackoff, IBackoffFactory } from './Backoff';
 
 export type DelegateBackoffFn<T, S = void> = (
   context: T,
@@ -10,41 +10,27 @@ export type DelegateBackoffFn<T, S = void> = (
  * the backoff context, and can optionally take (and return) a state value
  * that will be passed into subsequent backoff requests.
  */
-export class DelegateBackoff<T, S = void> implements IBackoff<T> {
-  private current: number = 0;
-  private attempts: number = -1;
-
-  constructor(private readonly fn: DelegateBackoffFn<T, S>, private readonly state?: S) {}
-
-  /**
-   * @inheritdoc
-   */
-  public duration() {
-    if (this.attempts === -1) {
-      throw new Error('duration is avaiable until the first next call');
-    }
-    return this.current;
-  }
+export class DelegateBackoff<T, S = void> implements IBackoffFactory<T> {
+  constructor(private readonly fn: DelegateBackoffFn<T, S>) {}
 
   /**
    * @inheritdoc
    */
   public next(context: T) {
-    const result = this.fn(context, this.state);
+    return instance(this.fn).next(context);
+  }
+}
+
+const instance = <T, S>(fn: DelegateBackoffFn<T, S>, state?: S, current = 0): IBackoff<T> => ({
+  duration: current,
+  next(context: T) {
+    const result = fn(context, state);
     if (result === undefined) {
       return undefined;
     }
 
-    let b: DelegateBackoff<T, S>;
-    if (typeof result === 'number') {
-      b = new DelegateBackoff(this.fn, this.state);
-      b.current = result;
-    } else {
-      b = new DelegateBackoff(this.fn, result.state);
-      b.current = result.delay;
-    }
-    b.attempts = this.attempts + 1;
-
-    return b;
-  }
-}
+    return typeof result === 'number'
+      ? instance(fn, state, result)
+      : instance(fn, result.state, result.delay);
+  },
+});

--- a/src/backoff/ExponentialBackoff.test.ts
+++ b/src/backoff/ExponentialBackoff.test.ts
@@ -5,11 +5,11 @@ import { noJitterGenerator } from './ExponentialBackoffGenerators';
 describe('ExponentialBackoff', () => {
   it('works', () => {
     const b = new ExponentialBackoff({ generator: noJitterGenerator });
-    expectDurations(b, [0, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 30000, 30000]);
+    expectDurations(b, [128, 256, 512, 1024, 2048, 4096, 8192, 16384, 30000, 30000, 30000]);
   });
 
   it('sets max retries correctly', () => {
     const b = new ExponentialBackoff({ generator: noJitterGenerator, maxAttempts: 4 });
-    expectDurations(b, [0, 128, 256, 512, undefined]);
+    expectDurations(b, [128, 256, 512, 1024, undefined]);
   });
 });

--- a/src/backoff/ExponentialBackoff.ts
+++ b/src/backoff/ExponentialBackoff.ts
@@ -1,4 +1,4 @@
-import { IBackoff } from './Backoff';
+import { IBackoff, IBackoffFactory } from './Backoff';
 import { decorrelatedJitterGenerator, GeneratorFn } from './ExponentialBackoffGenerators';
 
 /**
@@ -48,34 +48,34 @@ const defaultOptions: IExponentialBackoffOptions<any> = {
 /**
  * An implementation of exponential backoff.
  */
-export class ExponentialBackoff<S> implements IBackoff<void> {
-  private options: IExponentialBackoffOptions<S>;
-  private state?: S;
-  private attempt = -1;
-  private delay = 0;
+export class ExponentialBackoff<S> implements IBackoffFactory<unknown> {
+  private readonly options: IExponentialBackoffOptions<S>;
 
   constructor(options?: Partial<IExponentialBackoffOptions<S>>) {
     this.options = options ? { ...defaultOptions, ...options } : defaultOptions;
   }
 
-  /**
-   * @inheritdoc
-   */
-  public duration() {
-    if (this.attempt === -1) {
-      throw new Error('duration is avaiable until the first next call');
-    }
-    return this.delay;
-  }
-
   public next() {
-    if (this.attempt >= this.options.maxAttempts - 1) {
+    return instance(this.options).next(undefined);
+  }
+}
+
+/**
+ * An implementation of exponential backoff.
+ */
+const instance = <S>(
+  options: IExponentialBackoffOptions<S>,
+  state?: S,
+  delay = 0,
+  attempt = -1,
+): IBackoff<unknown> => ({
+  duration: delay,
+  next() {
+    if (attempt >= options.maxAttempts - 1) {
       return undefined;
     }
 
-    const e = new ExponentialBackoff(this.options);
-    [e.delay, e.state] = this.options.generator(this.state, this.options);
-    e.attempt = this.attempt + 1;
-    return e;
-  }
-}
+    const [delay, nextState] = options.generator(state, options);
+    return instance(options, nextState, delay, attempt + 1);
+  },
+});

--- a/src/backoff/ExponentialBackoff.ts
+++ b/src/backoff/ExponentialBackoff.ts
@@ -63,7 +63,7 @@ export class ExponentialBackoff<S> implements IBackoff<void> {
    */
   public duration() {
     if (this.attempt === -1) {
-      throw Error(`duration is avaiable until the first next call`);
+      throw new Error('duration is avaiable until the first next call');
     }
     return this.delay;
   }

--- a/src/backoff/ExponentialBackoff.ts
+++ b/src/backoff/ExponentialBackoff.ts
@@ -75,7 +75,7 @@ const instance = <S>(
       return undefined;
     }
 
-    const [delay, nextState] = options.generator(state, options);
-    return instance(options, nextState, delay, attempt + 1);
+    const [nextDelay, nextState] = options.generator(state, options);
+    return instance(options, nextState, nextDelay, attempt + 1);
   },
 });

--- a/src/backoff/ExponentialBackoff.ts
+++ b/src/backoff/ExponentialBackoff.ts
@@ -51,7 +51,7 @@ const defaultOptions: IExponentialBackoffOptions<any> = {
 export class ExponentialBackoff<S> implements IBackoff<void> {
   private options: IExponentialBackoffOptions<S>;
   private state?: S;
-  private attempt = 0;
+  private attempt = -1;
   private delay = 0;
 
   constructor(options?: Partial<IExponentialBackoffOptions<S>>) {
@@ -62,6 +62,9 @@ export class ExponentialBackoff<S> implements IBackoff<void> {
    * @inheritdoc
    */
   public duration() {
+    if (this.attempt === -1) {
+      throw Error(`duration is avaiable until the first next call`);
+    }
     return this.delay;
   }
 

--- a/src/backoff/IterableBackoff.test.ts
+++ b/src/backoff/IterableBackoff.test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { expectDurations } from './Backoff.test';
 import { IterableBackoff } from './IterableBackoff';
 
@@ -6,9 +5,5 @@ describe('IterableBackoff', () => {
   it('works', () => {
     const b = new IterableBackoff([3, 6, 9]);
     expectDurations(b, [3, 6, 9, undefined]);
-  });
-
-  it('throws a range error if empty', () => {
-    expect(() => new IterableBackoff([])).to.throw(RangeError);
   });
 });

--- a/src/backoff/IterableBackoff.ts
+++ b/src/backoff/IterableBackoff.ts
@@ -14,7 +14,7 @@ export class IterableBackoff implements IBackoff<void> {
    */
   public duration() {
     if (this.index === -1) {
-      throw new Error(`duration is avaiable until the first next call`);
+      throw new Error('duration is avaiable until the first next call');
     }
     return this.durations[this.index];
   }

--- a/src/backoff/IterableBackoff.ts
+++ b/src/backoff/IterableBackoff.ts
@@ -6,19 +6,16 @@ import { IBackoff } from './Backoff';
 export class IterableBackoff implements IBackoff<void> {
   constructor(
     private readonly durations: ReadonlyArray<number>,
-    private readonly index: number = 0,
-  ) {
-    if (index >= durations.length) {
-      throw new RangeError(
-        `IterableBackoff index ${0} >= number of durations (${durations.length})`,
-      );
-    }
-  }
+    private readonly index: number = -1,
+  ) {}
 
   /**
    * @inheritdoc
    */
   public duration() {
+    if (this.index === -1) {
+      throw new Error(`duration is avaiable until the first next call`);
+    }
     return this.durations[this.index];
   }
 


### PR DESCRIPTION
This PR is attempt to fix the issue reported by issue #30. 
The basic idea is to make sure `duration` call must be called after the first `next` call.  This will make sure DelegateBackoff and ExponentialBackoff could be initialized properly based on the input.