### PR TITLE
Fix readme example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,18 +23,18 @@ import { database } from './my-db';
 
 // Create a retry policy that'll try whatever function we execute 3
 // times with a randomized exponential backoff.
-const retry = retry(handleAll, { maxAttempts: 3, backoff: new ExponentialBackoff() });
+const retryPolicy = retry(handleAll, { maxAttempts: 3, backoff: new ExponentialBackoff() });
 
 // Create a circuit breaker that'll stop calling the executed function for 10
 // seconds if it fails 5 times in a row. This can give time for e.g. a database
 // to recover without getting tons of traffic.
-const circuitBreaker = circuitBreaker(handleAll, {
+const circuitBreakerPolicy = circuitBreaker(handleAll, {
   halfOpenAfter: 10 * 1000,
   breaker: new ConsecutiveBreaker(5),
 });
 
 // Combine these! Create a policy that retries 3 times, calling through the circuit breaker
-const retryWithBreaker = wrap(retry, circuitBreaker);
+const retryWithBreaker = wrap(retryPolicy, circuitBreakerPolicy);
 
 exports.handleRequest = async (req, res) => {
   // Call your database safely!


### PR DESCRIPTION
The example was using variable names that are the same as the imports. This doesn't compile due to ambiguity.