### PR TITLE
feat: remove `as Error` type assertions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -472,7 +472,7 @@ export interface IRetryBackoffContext<ReturnType> {
    * The result of the last method call. Either a thrown error, or a value
    * that we determined should be retried upon.
    */
-  result: { error: Error } | { value: ReturnType };
+  result: { error: unknown } | { value: ReturnType };
 }
 ```
 

--- a/src/BulkheadPolicy.ts
+++ b/src/BulkheadPolicy.ts
@@ -10,7 +10,7 @@ interface IQueueItem<T> {
   signal: AbortSignal;
   fn(context: IDefaultPolicyContext): Promise<T> | T;
   resolve(value: T): void;
-  reject(error: Error): void;
+  reject(error: unknown): void;
 }
 
 export class BulkheadPolicy implements IPolicy {

--- a/src/Policy.test.ts
+++ b/src/Policy.test.ts
@@ -86,7 +86,7 @@ describe('Policy', () => {
         handleType(MyError1)
           .orType(MyError2)
           .orType(MyError3, e => e.message === 'foo')
-          .orWhen(e => e.message === 'potato'),
+          .orWhen(e => e instanceof Error && e.message === 'potato'),
         { maxAttempts: 10 },
       ).execute(fn),
     ).to.be.rejectedWith(MyError3, 'bar');

--- a/src/Policy.ts
+++ b/src/Policy.ts
@@ -18,7 +18,7 @@ const always = () => true;
 const never = () => false;
 
 export interface IBasePolicyOptions {
-  errorFilter: (error: Error) => boolean;
+  errorFilter: (error: unknown) => boolean;
   resultFilter: (result: unknown) => boolean;
 }
 
@@ -26,7 +26,7 @@ export interface IBasePolicyOptions {
  * The reason for a call failure. Either an error, or the a value that was
  * marked as a failure (when using result filtering).
  */
-export type FailureReason<ReturnType> = { error: Error } | { value: ReturnType };
+export type FailureReason<ReturnType> = { error: unknown } | { value: ReturnType };
 
 /**
  * Event emitted on the `onFailure` calls.
@@ -165,7 +165,7 @@ export class Policy {
    *  .execute(() => getJsonFrom('https://example.com'));
    * ```
    */
-  public orWhen(predicate: (error: Error) => boolean) {
+  public orWhen(predicate: (error: unknown) => boolean) {
     return new Policy({
       ...this.options,
       errorFilter: e => this.options.errorFilter(e) || predicate(e),
@@ -237,7 +237,7 @@ export function handleType<T>(cls: Constructor<T>, predicate?: (error: T) => boo
 /**
  * See {@link Policy.orWhen} for usage.
  */
-export function handleWhen(predicate: (error: Error) => boolean) {
+export function handleWhen(predicate: (error: unknown) => boolean) {
   return new Policy({ errorFilter: predicate, resultFilter: never });
 }
 /**

--- a/src/common/Executor.ts
+++ b/src/common/Executor.ts
@@ -34,7 +34,7 @@ export class ExecuteWrapper {
   public readonly onFailure = this.failureEmitter.addListener;
 
   constructor(
-    private readonly errorFilter: (error: Error) => boolean = () => false,
+    private readonly errorFilter: (error: unknown) => boolean = () => false,
     private readonly resultFilter: (result: unknown) => boolean = () => false,
   ) {}
 
@@ -62,9 +62,8 @@ export class ExecuteWrapper {
       }
 
       return { value };
-    } catch (rawError) {
-      const error = rawError as Error;
-      const handled = this.errorFilter(error as Error);
+    } catch (error) {
+      const handled = this.errorFilter(error);
       if (stopwatch) {
         this.failureEmitter.emit({ duration: stopwatch(), handled, reason: { error } });
       }

--- a/src/common/defer.ts
+++ b/src/common/defer.ts
@@ -1,6 +1,6 @@
 export const defer = <T>() => {
   let resolve: (value: T) => void;
-  let reject: (error: Error) => void;
+  let reject: (error: unknown) => void;
   const promise = new Promise<T>((res, rej) => {
     resolve = res;
     reject = rej;


### PR DESCRIPTION
Instead, errors are now consistently typed as `unknown`.

BREAKING CHANGE: The types of errors have been changed from `Error` to unknown because they are not statically known (in JavaScript, _anything_ can be thrown). If you know that in a particular situation, errors can only be instances of `Error`, you can do the type assertion yourself (`error as Error`). Otherwise, you should check whether an error is actually an `Error`, for example with `error instanceof Error`.

Closes #87