### PR TITLE
docs(timeout): `TaskCancelledError` never gets executed on Cooperative

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -818,7 +818,7 @@ Creates a timeout policy. The duration specifies how long to wait before timing 
 ```js
 import { TimeoutStrategy, timeout, TaskCancelledError } from 'cockatiel';
 
-const timeout = timeout(2000, TimeoutStrategy.Cooperative);
+const timeout = timeout(2000, TimeoutStrategy.Aggressive);
 
 export async function handleRequest() {
   try {


### PR DESCRIPTION
`TimeoutStrategy.Cooperative` throws the delegate exception, so it won't fire `TaskCancelledError` as shown in example. Switching to `TimeoutStrategy.Aggressive` is required to the example to work as expected.