### PR TITLE
Add package exports and types field to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,20 @@
   "version": "3.2.1",
   "description": "A resilience and transient-fault-handling library that allows developers to express policies such as Backoff, Retry, Circuit Breaker, Timeout, Bulkhead Isolation, and Fallback in a fluent and thread-safe manner. Inspired by .NET Polly.",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "module": "dist/esm/index.js",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
   "engines": {
     "node": ">=16"
   },


### PR DESCRIPTION
The package currently only specifies a `main` (for CJS) and `module` (for ESM) field, but Node.js does not support the `module` field. I've added an `exports` field which is the standard for package exports nowadays, and ensures modern tools that don't support `module` can also use the ESM version.

Note that this is technically a breaking change, as it's no longer possible for packages to import files from `dist` directly when `exports` is specified. For example, `import 'cockatiel/dist/some-file.js';` will no longer work.