### PR TITLE
chore(deps): Update @types/node to version 18.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@types/chai-as-promised": "^7.1.5",
         "@types/chai-subset": "^1.3.3",
         "@types/mocha": "^9.1.1",
-        "@types/node": "^16.11.7",
+        "@types/node": "18.x",
         "@types/sinon": "^10.0.11",
         "@types/sinon-chai": "^3.2.8",
         "chai": "^4.3.6",
@@ -639,10 +639,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.11.36",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.36.tgz",
-      "integrity": "sha512-FR5QJe+TaoZ2GsMHkjuwoNabr+UrJNRr2HNOo+r/7vhcuntM6Ee/pRPOnRhhL2XE9OOvX9VLEq+BcXl3VjNoWA==",
-      "dev": true
+      "version": "18.19.123",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.123.tgz",
+      "integrity": "sha512-K7DIaHnh0mzVxreCR9qwgNxp3MH9dltPNIEddW9MYUlcKAzm+3grKNSTe2vCJHI1FaLpvpL5JGJrz1UZDKYvDg==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/sinon": {
       "version": "10.0.11",
@@ -4136,6 +4139,12 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "node_modules/unified": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.0.tgz",
@@ -4292,6 +4301,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/unified-engine/node_modules/@types/node": {
+      "version": "16.18.126",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
+      "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
+      "dev": true
     },
     "node_modules/unified-engine/node_modules/argparse": {
       "version": "2.0.1",
@@ -5310,10 +5325,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.11.36",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.36.tgz",
-      "integrity": "sha512-FR5QJe+TaoZ2GsMHkjuwoNabr+UrJNRr2HNOo+r/7vhcuntM6Ee/pRPOnRhhL2XE9OOvX9VLEq+BcXl3VjNoWA==",
-      "dev": true
+      "version": "18.19.123",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.123.tgz",
+      "integrity": "sha512-K7DIaHnh0mzVxreCR9qwgNxp3MH9dltPNIEddW9MYUlcKAzm+3grKNSTe2vCJHI1FaLpvpL5JGJrz1UZDKYvDg==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/sinon": {
       "version": "10.0.11",
@@ -7830,6 +7848,12 @@
       "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
       "dev": true
     },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "unified": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.0.tgz",
@@ -7950,6 +7974,12 @@
         "vfile-statistics": "^2.0.0"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "16.18.126",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
+          "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
+          "dev": true
+        },
         "argparse": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@types/chai-as-promised": "^7.1.5",
     "@types/chai-subset": "^1.3.3",
     "@types/mocha": "^9.1.1",
-    "@types/node": "^16.11.7",
+    "@types/node": "18.x",
     "@types/sinon": "^10.0.11",
     "@types/sinon-chai": "^3.2.8",
     "chai": "^4.3.6",


### PR DESCRIPTION
Upgrade the @types/node package to version 18.x to support AbortSignal signature.