### PR TITLE
fix: deep copy state in count/sampling breaker getter/setter

### DIFF
--- a/src/breaker/CountBreaker.ts
+++ b/src/breaker/CountBreaker.ts
@@ -46,7 +46,7 @@ export class CountBreaker implements IBreaker {
    */
   public get state(): unknown {
     return {
-      samples: this.samples,
+      samples: [...this.samples],
       currentSample: this.currentSample,
       failures: this.failures,
       successes: this.successes,
@@ -57,7 +57,9 @@ export class CountBreaker implements IBreaker {
    * @inheritdoc
    */
   public set state(value: unknown) {
-    Object.assign(this, value);
+    const { samples, ...rest } = value as ICountBreakerState;
+    Object.assign(this, rest);
+    this.samples = [...samples];
   }
 
   /**

--- a/src/breaker/SamplingBreaker.ts
+++ b/src/breaker/SamplingBreaker.ts
@@ -49,7 +49,7 @@ export class SamplingBreaker implements IBreaker {
    */
   public get state(): unknown {
     return {
-      windows: this.windows,
+      windows: this.windows.map(w => ({ ...w })),
       currentWindow: this.currentWindow,
       currentFailures: this.currentFailures,
       currentSuccesses: this.currentSuccesses,
@@ -60,7 +60,9 @@ export class SamplingBreaker implements IBreaker {
    * @inheritdoc
    */
   public set state(value: unknown) {
-    Object.assign(this, value);
+    const { windows, ...rest } = value as ISamplingBreakerState;
+    Object.assign(this, rest);
+    this.windows = windows.map(w => ({ ...w }));
   }
 
   /**


### PR DESCRIPTION
The getters and setters in the count breaker and sampling breaker were exposing the internal state instead of doing a deep copy. This PR fixes that.