### PR TITLE
fix: queue starvation bug in bulkhead policy

### DIFF
--- a/src/BulkheadPolicy.test.ts
+++ b/src/BulkheadPolicy.test.ts
@@ -157,4 +157,25 @@ describe('Bulkhead', () => {
 
     await Promise.all(todo);
   });
+
+  it('should process next queued item when previous item was aborted', async () => {
+    const b = bulkhead(1, 10);
+    const defer1 = defer<number>();
+    const abortController = new AbortController();
+
+    const promise1 = b.execute(() => defer1.promise);
+
+    const promise2 = b.execute(() => 2, abortController.signal);
+    const promise3 = b.execute(() => 3);
+
+    abortController.abort();
+    defer1.resolve(1);
+    await promise1;
+
+    await expect(promise2).to.be.rejectedWith(TaskCancelledError);
+    expect(await promise3).to.equal(3);
+
+    expect(b.executionSlots).to.equal(1);
+    expect(b.queueSlots).to.equal(10);
+  });
 });

--- a/src/BulkheadPolicy.ts
+++ b/src/BulkheadPolicy.ts
@@ -67,10 +67,6 @@ export class BulkheadPolicy implements IPolicy {
     fn: (context: IDefaultPolicyContext) => PromiseLike<T> | T,
     signal = neverAbortedSignal,
   ): Promise<T> {
-    if (signal.aborted) {
-      throw new TaskCancelledError();
-    }
-
     if (this.active < this.capacity) {
       this.active++;
       try {
@@ -94,6 +90,12 @@ export class BulkheadPolicy implements IPolicy {
   private dequeue() {
     const item = this.queue.shift();
     if (!item) {
+      return;
+    }
+
+    if (item.signal.aborted) {
+      item.reject(new TaskCancelledError());
+      this.dequeue();
       return;
     }
 


### PR DESCRIPTION
When a signal was aborted, there was no dequeue, which meant that there was an execution slot that was being held by an aborted task. This PR fixes that (with a previously failing unit test as well)